### PR TITLE
use cvmfs_rsync in do_oasis_update (OO-97)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.0.38
+
+* Add misc/cvmfs_rsync to the package and use it from misc/do_oasis_update
+
 2.0.37
 
 * Add misc/replicate_whitelists to copy the .cvmfswhitelist for every

--- a/install/install-oasis
+++ b/install/install-oasis
@@ -49,7 +49,7 @@ CVMFSVER=2.1.20
 CVMFSRPM=cvmfs-$CVMFSVER-1.el5.$ARCH.rpm
 CVMFSSERVERRPM=cvmfs-server-$CVMFSVER-1.el5.$ARCH.rpm
 CVMFSCONFIGRPM=cvmfs-config-default-1.1-1.noarch.rpm
-OASISRPM=oasis-2.0.37-1.osg32.el5.noarch.rpm
+OASISRPM=oasis-2.0.38-1.osg32.el5.noarch.rpm
 
 PATH="$PATH:/sbin"
 

--- a/misc/cvmfs_rsync
+++ b/misc/cvmfs_rsync
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Rsync directories into cvmfs.
+
+ME=cvmfs_rsync
+
+usage()
+{
+    echo "$ME [rsync_options] srcdir /cvmfs/reponame[/destsubdir]" >&2
+    echo "  Rsync to cvmfs repositories.  Avoids .cvmfscatalog files while allowing"
+    echo "  directories containing them to be deleted when their source goes away." >&2
+    exit 1
+}
+
+if [ $# -lt 2 ]; then
+    usage
+fi
+
+# readlink -m canonicalizes paths, removing extra slashes, etc.
+DEST="`readlink -m ${@:$#}`"
+let IDX="$# - 1"
+SRC="${@:$IDX:1}"
+let IDX-=1
+RSYNC_OPTIONS="${@:1:$IDX} --exclude .cvmfscatalog"
+
+DESTWITHOUTCVMFS="${DEST#/cvmfs/}"
+if [ "DESTWITHOUTCVMFS" = "$DEST" ]; then
+    echo "$ME: destination does not begin with /cvmfs/" >&2
+    usage
+fi
+
+REPO="${DESTWITHOUTCVMFS%%/*}"
+if [ -z "$REPO" ]; then
+    echo "$ME: no reponame given" >&2
+    usage
+fi
+
+DESTSUBDIR="${DESTWITHOUTCVMFS%*/}"
+
+if [[ "$SRC" =~ ^[^/]*: ]]; then
+    echo "$ME: srcdir must be locally mounted, not a remote host, sorry" >&2
+    usage
+fi
+
+if [ -f /cvmfs/$REPO/.cvmfsdirtab ]; then
+    DESTDIR="$DEST"
+    if [ "${SRC%/}" = "$SRC" ]; then
+	# there's no trailing slash, so rsync will append $SRC basename to $DEST
+	DESTDIR="$DEST/${SRC##*/}"
+    fi
+    # look for entries that match under $DESTSUBDIR and expand them to
+    #   see if any of them have .cvmfscatalog files in directories
+    #   that have gone away from the source.
+    grep -vE '^(!|#)' /cvmfs/$REPO/.cvmfsdirtab|while read PAT; do
+	FULLPAT="/cvmfs/$REPO$PAT"
+	PATSLASHES="${FULLPAT//[^\/]}"
+	let NPATFIELDS="${#PATSLASHES} + 1"
+	DESTSLASHES="${DESTDIR//[^\/]}"
+	let NDESTFIELDS="${#DESTSLASHES} + 1"
+	MATCHPAT="$FULLPAT"
+	if [ $NPATFIELDS -gt $NDESTFIELDS ]; then
+	    MATCHPAT="`echo "$FULLPAT"|cut -d/ -f-$NDESTFIELDS`"
+	fi
+	if [ "${DESTDIR#$MATCHPAT}" != "$DESTDIR" ]; then
+	    # $PAT matches $DESTDIR, look in all matching directories
+	    let NDESTFIELDS+=1
+	    SUBPAT="`echo "$FULLPAT"|cut -d/ -f$NDESTFIELDS-`"
+	    if [ -n "$SUBPAT" ]; then
+		SUBPAT="/$SUBPAT"
+	    fi
+	    # enable dotglob because .cvmfsdirtab matches dots
+	    for D in `shopt -s dotglob;echo $DESTDIR$SUBPAT 2>/dev/null`; do
+		SRCSUBD="${D#$DESTDIR/}"
+		if [ "$SRCSUBD" = "$D" ]; then
+		    # it didn't really match, the .cvmfsdirtab pattern
+		    #  included other directories outside of this one
+		    # (shouldn't happen because of $SUBPAT, but just in case)
+		    continue
+		fi
+		if [ -f $D/.cvmfscatalog ] && [ ! -d $SRC/$SRCSUBD ]; then
+		    echo "removing .cvmfscatalog from deleted ${D#$DEST/}"
+		    rm -f $D/.cvmfscatalog
+		fi
+	    done
+	fi
+    done
+fi
+
+exec rsync $RSYNC_OPTIONS $SRC $DEST

--- a/misc/do_oasis_update
+++ b/misc/do_oasis_update
@@ -35,20 +35,7 @@ if [ -f ${LOCKPFX}oasis_update_lock ]; then
 	    $runuser "cp $SRCDIRTAB $DSTDIRTAB"
 	fi
 
-	# Remove .cvmfscatalog files in target directories that have been
-	#   removed from the source.  Without this, rsync can't remove
-	#   directories that contain catalogs.
-	grep "^/$vo/" $DSTDIRTAB|while read pat; do
-	    for dir in `echo /cvmfs/oasis.opensciencegrid.org$pat 2>/dev/null`; do
-		srcdir="`echo $dir|sed 's,/cvmfs/oasis.opensciencegrid.org/,,'`"
-		if [ ! -d "/net/nas01/Public/ouser.$srcdir" ] && [ -f "$dir/.cvmfscatalog" ]; then
-		    echo "removing .cvmfscatalog from deleted $srcdir"
-		    rm -f $dir/.cvmfscatalog
-		fi
-	    done
-	done
-
-	$runuser "rsync -aW --stats --exclude .cvmfscatalog --delete --force --ignore-errors /net/nas01/Public/ouser.$vo/ /cvmfs/oasis.opensciencegrid.org/$vo"
+	$runuser "/usr/share/oasis/cvmfs_rsync -aW --stats --delete --force --ignore-errors /net/nas01/Public/ouser.$vo/ /cvmfs/oasis.opensciencegrid.org/$vo"
 
 	now=`date`
 	echo "$now starting cvmfs_server publish"

--- a/misc/oasis.spec
+++ b/misc/oasis.spec
@@ -1,5 +1,5 @@
 %define name oasis
-%define version 2.0.37
+%define version 2.0.38
 %define release 1
 
 Summary: OASIS package
@@ -153,7 +153,10 @@ f_restart_daemon $1
 # Changelog
 #-------------------------------------------------------------------------------
 %changelog
-* Wed Sep 22 2015 Dave Dykstra <dwd@fnal.gov> - 2.0.37-1
+* Thu Oct 01 2015 Dave Dykstra <dwd@fnal.gov> - 2.0.38-1
+- Add misc/cvmfs_rsync to the package and use it from misc/do_oasis_update
+
+* Wed Sep 23 2015 Dave Dykstra <dwd@fnal.gov> - 2.0.37-1
 - Add misc/replicate_whitelists to copy the .cvmfswhitelist for every
   repository from oasis to oasis-replica
 - Update misc/oasis_replica_status to warn when any whitelist is more than

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # Setup prog for OASIS 
 #
 #
-release_version='2.0.37'
+release_version='2.0.38'
 
 import commands
 import os
@@ -23,6 +23,7 @@ from distutils.command.install_data import install_data as install_data_org
 libexec_files = ['libexec/%s' %file for file in os.listdir('libexec') if os.path.isfile('libexec/%s' %file)]
 
 utils_files = ['misc/cvmfs_server_hooks.sh',
+               'misc/cvmfs_rsync',
                'misc/do_oasis_update',
                'misc/generate_adduser',
                'misc/generate_condormap',


### PR DESCRIPTION
Brian, please merge.  cvmfs_rsync has already been in production use for fermilab.opensciencegrid.org and is to be contributed upstream (CVM-814).  The only modification to it to support deleting directories  with '.' containing .cvmfscatalog was to add 'shopt -s dotglob' to get bash to match dot files.  I have tested this change on oasis-itb with a scratch build, waiting on a merge to do final build.
