### PR TITLE
code to run snapshots at Stratum-1s with a daemon instead of cron

### DIFF
--- a/bin/oasisreplicad
+++ b/bin/oasisreplicad
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+"""
+Very simple wrapper to be executed by init script. 
+"""
+
+from oasispackage.oasisreplicaAPI import oasisreplicad
+
+def main():
+
+    oasisreplicadaemon = oasisreplicad()
+    oasisreplicadaemon.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/etc/oasisreplica.conf
+++ b/etc/oasisreplica.conf
@@ -1,0 +1,3 @@
+[REPLICA]
+
+repositoriesConf = /etc/oasisreplica/oasisreplicarepositories.conf

--- a/etc/oasisreplicad
+++ b/etc/oasisreplicad
@@ -1,0 +1,213 @@
+#!/bin/bash
+#
+#	/etc/rc.d/init.d/oasis
+#
+# Starts the OASIS daemon
+#
+# chkconfig: 2345 90 60 
+# description: run probes and publishing files for OASIS
+# processname: oasisreplica
+# config: /etc/oasis/oasisreplica.conf 
+# pidfile: /var/run/oasisreplica.pid
+#
+#
+
+### BEGIN INIT INFO
+# Required-Start: $syslog $local_fs
+# Required-Stop: $syslog $local_fs
+# Default-Start:  2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: start and stop OASIS daemon
+# Description: run probes and publishing files for OASIS
+### END INIT INFO
+
+f_dir(){
+    # little function to find out where actually
+    # this script is located.
+    # In case of an user custom installation it could
+    # be in a place different that both /etc/init.d/ or the $HOME dir.
+    # The current location is recorded in variable OASISDIR
+    
+    OLD_DIR=$PWD
+    DIRPATH=`dirname $0`
+    cd $DIRPATH
+    OASISDIR=$PWD
+    cd $OLD_DIR
+}
+
+# Source function library.
+# Standard RedHat
+if [ -f /etc/rc.d/init.d/functions ]; then
+   . /etc/rc.d/init.d/functions
+fi
+
+# Use LSB locations for e.g. SuSE
+if [ -f /lib/lsb/init-functions ]; then
+   . /lib/lsb/init-functions
+fi
+
+# Source standard environment
+for i in /etc/profile.d/*.sh; do
+    if [ -r "$i" ]; then
+            . $i >/dev/null 2>&1
+    fi
+done
+
+# Determine usage context and set paths accordingly.  
+#   -- for root it means RPM
+#   -- for non-root, the head of the path tree can be calculated from the output of f_oasisdir
+#      the relative paths for the rest of files are like ../bin, ../var, etc.
+#      In case of non-root, it cannot be a regular user. 
+#      It should be a special dedicated user, i.e. 'oasis'
+
+f_dir
+
+if [ `id -u` = 0 ]; then
+    OASISHEAD=/
+    SYSCONF=/etc/sysconfig/oasisreplica
+    BINDIR=/usr/bin
+    ETCDIR=/etc/oasisreplica
+    PIDFILE=/var/run/oasisreplicad.pid
+else
+    OASISHEAD=`dirname $OASISDIR`
+
+    SYSCONF=$OASISHEAD/etc/oasisreplica
+    BINDIR=$OASISHEAD/bin
+    ETCDIR=$OASISHEAD/etc
+    PIDFILE=$OASISHEAD/var/run/oasisreplicad.pid
+fi
+
+CONFFILE=$ETCDIR/oasisreplica.conf
+
+# Source settings from sysconfig
+# overriding default if present
+
+if [ -f $SYSCONF ]; then
+   . $SYSCONF
+fi
+
+if [ -f /etc/profile ]; then
+   . /etc/profile
+fi
+
+
+RETVAL=0
+#
+# See how we were called.
+#
+check() {
+	
+	# Check if oasisreplicad is executable
+	test -x $BINDIR/oasisreplicad || exit 5
+}
+
+create_var_run(){
+    # function to create directory  $OASISHEAD/var/run 
+    # if it does not exist. 
+    # It is needed to place the file oasisreplica.pid 
+    if [ ! -d $OASISHEAD/var/run/ ]; then
+        mkdir -p $OASISHEAD/var/run/
+    fi
+}
+
+create_var_log(){
+    # function to create directory  $OASISHEAD/var/log/oasisreplica
+    # if it does not exist. 
+    if [ ! -d $OASISHEAD/var/log/oasisreplica ]; then
+        mkdir -p $OASISHEAD/var/log/oasisreplica/
+    fi
+}
+
+
+start() {
+	# Check if it is already running
+	PROGRETVAL=0
+	if [ ! -f $PIDFILE ]; then
+		echo -n $"Starting OASIS daemon: "	
+        create_var_run
+        create_var_log
+	    # daemon --pidfile=${PIDFILE} "$BINDIR/oasisreplicad --conf $CONFFILE $OPTIONS "
+        if [ -n "$CONSOLE_LOG" ]; then
+        	#$BINDIR/oasisreplicad --conf $CONFFILE $OPTIONS >> $CONSOLE_LOG 2>&1 &
+        	$BINDIR/oasisreplicad $OPTIONS >> $CONSOLE_LOG 2>&1 &
+        else
+            #$BINDIR/oasisreplicad --conf $CONFFILE $OPTIONS &
+            $BINDIR/oasisreplicad $OPTIONS &
+        fi
+        RETVAL=$?
+		PID=$!
+	    [ "$RETVAL" -eq 0 ] && echo $! > $PIDFILE        
+
+		sleep 3
+		if checkpid $PID; then
+			PROGRETVAL=0
+		else
+			wait $PID
+			PROGRETVAL=$?
+			rm -f $PIDFILE
+		fi
+        [ "$PROGRETVAL" -eq 0 ] && success $"oasisreplicad startup" || failure $"oasisreplicad startup"
+	    echo
+	else
+		if checkpid $PID; then
+			echo "$0: daemon with PID $PID already running." && success $"oasisreplicad startup"
+			PROGRETVAL=0
+		else
+			echo "$0: daemon dead but PID file exists: $PIDFILE" && failure $"oasisreplicad startup"
+	    	PROGRETVAL=1
+	    fi
+	fi
+
+	return $PROGRETVAL
+}
+
+stop() {
+
+	check
+	echo -n $"Stopping OASIS replica daemon: "
+	killproc -p $PIDFILE oasisreplicad
+	RETVAL=$?
+	[ $RETVAL -eq 0 ] && rm -f $PIDFILE && success $"oasisreplicad shutdown" || failure $"oasisreplicad shutdown"
+	echo
+    return $RETVAL
+}
+
+
+restart() {
+	stop
+	sleep 2
+	start
+	RETVAL=$?
+	return $RETVAL
+}	
+
+case "$1" in
+start)
+    start
+    RETVAL=$?
+    ;;
+stop)
+    stop
+    RETVAL=$?
+    ;;
+restart)
+	restart
+	RETVAL=$?
+	;;
+condrestart)
+	#if [ -f /var/lock/subsys/oasisreplicad ]; then
+	if [ -f /var/run/oasisreplicad.pid ]; then
+	    restart
+	fi
+	RETVAL=$?
+	;;
+status)
+	status oasisreplicad
+	RETVAL=$?
+	;;
+*)
+	echo $"Usage: $0 {start|stop|status|restart|condrestart}"
+	RETVAL=2
+esac
+
+exit $RETVAL

--- a/etc/oasisreplicarepositories.conf
+++ b/etc/oasisreplicarepositories.conf
@@ -1,0 +1,26 @@
+#
+# configuration file, repository by repository, 
+# for service (daemon) oasisreplica
+#
+# enabled = True|False
+#
+# repository = name of the repository to be replicated.
+#              matches /cvmfs/<repository>/
+#
+# interval = time, in seconds, between replication cycles
+#
+# ntrials = number of times to try replicating the repository,
+#           in case of failures
+#
+
+[REPO1]
+enabled = False
+repository = oasis.opensciencegrid.org
+interval = 600
+ntrials = 3
+
+[REPO2]
+enabled = False
+repository = atlas.cern.ch
+interval = 600
+ntrials = 3

--- a/etc/sysconfig/oasisreplica
+++ b/etc/sysconfig/oasisreplica
@@ -1,0 +1,23 @@
+#
+# Sysconfig file for OASIS daemon
+#
+
+#
+#  VERY IMPORTANT : cp this file to /etc/sysconfig/oasisreplica
+#
+
+#  OPTIONS:
+#   
+#  --conf=FILE           Load configuration from FILE
+#
+#  --loglevel    
+#    --debug             Set logging level to DEBUG [default WARNING]
+#    --info              Set logging level to INFO [default WARNING]
+#    --warning           Set logging level to WARNING [default WARNING]
+#
+#  --logfile=LOGFILE     Send logging output to LOGFILE or SYSLOG or stdout
+#                        [default <syslog>]
+
+OPTIONS="--conf=/etc/oasis/oasisreplica.conf --loglevel=info --logfile=/var/log/oasis/oasisreplicad.log"
+#CONSOLE_LOG=/var/log/oasis/console.log
+

--- a/oasispackage/oasisreplicaAPI.py
+++ b/oasispackage/oasisreplicaAPI.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python   
+
+#
+#  FIXME : temporary name
+#
+
+
+import commands
+import datetime
+import getopt
+import logging
+import logging.handlers
+import os
+import pwd
+import re
+import subprocess
+import string
+import sys
+import time
+import threading
+import traceback
+
+from ConfigParser import SafeConfigParser
+
+major, minor, release, st, num = sys.version_info
+
+
+
+class oasisreplicad(object):
+    '''
+    class to be invoked by the OASIS replica daemon.
+    '''
+
+    def __init__(self):
+
+        # FIXME
+        # maybe parsing the input options should have be done already
+        # in that case, the client /usr/bin/oasisd
+        # would call a factory class, instead of directly class oasisd() 
+        self._parseopts()
+
+        self._setuplogging()
+
+        try:
+            self.oasisreplicaconf = self._getbasicconfig()
+            oasisreplicarepositoriesconffile = self.oasisreplicaconf.get('REPLICA','repositoriesConf') 
+            self.oasisreplicarepositoriesconf = SafeConfigParser()
+            self.oasisreplicarepositoriesconf.readfp(open(oasisreplicarepositoriesconffile))
+        except:
+            self.log.critical('Configuration cannot be read. Aborting.')
+            sys.exit(1)
+
+        self.replicathreadsmanager = ReplicaThreadsManager(self)
+
+
+        self.log.debug('Object oasisd created.')
+
+
+    # --------------------------------------------------------------
+    #      P R E L I M I N A R I E S
+    # --------------------------------------------------------------
+
+    def _parseopts(self):
+        '''
+        parsing the input options.
+        These inputs are setup in /etc/sysconfig/oasisd.sysconfig
+        '''
+
+        opts, args = getopt.getopt(sys.argv[1:], '', ['conf=', 'loglevel=', 'logfile='])
+        for o, a in opts:
+
+            # FIXME 
+            # ?? should they have default values in case they are not passed from sysconfig ??
+            if o == '--conf':
+                self.conffile = a
+
+            if o == '--loglevel':
+                if a == 'debug':
+                    self.loglevel = logging.DEBUG
+                elif a == 'info':
+                    self.loglevel = logging.INFO
+                elif a == 'warning':
+                    self.loglevel = logging.WARNING
+
+            if o == '--logfile':
+                self.logfile = a
+        
+
+    def _setuplogging(self):
+        
+        self.log = logging.getLogger('oasisreplica')
+
+        # set the messages format
+        if major == 2 and minor == 4:
+            LOGFILE_FORMAT='%(asctime)s (UTC) - OASIS [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d : %(message)s'
+        else:
+            LOGFILE_FORMAT='%(asctime)s (UTC) - OASIS [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d %(funcName)s(): %(message)s'
+        logfile_formatter = logging.Formatter(LOGFILE_FORMAT)
+        logfile_formatter.converter = time.gmtime  # to convert timestamps to UTC
+       
+        logStream = logging.FileHandler(self.logfile)
+        logStream.setFormatter(logfile_formatter)
+        self.log.addHandler(logStream)
+        self.log.setLevel(self.loglevel)  
+        
+
+    # --------------------------------------------------------------
+
+    def _getbasicconfig(self):
+        '''
+        returns a ConfigParser object for oasis.conf
+        '''
+        self.log.debug('Start')
+        oasisreplicaconf = SafeConfigParser()
+        oasisreplicaconf.readfp(open(self.conffile))
+        self.log.debug('Leaving with config object %s' %oasisreplicaconf)
+        return oasisreplicaconf
+
+
+
+
+    def run(self):
+        """
+        """
+        self.log.debug('Start')
+    
+        try: 
+            self.log.info('creating ReplicaThreadsManager object and entering main loop')
+            self.replicathreadsmanager.update()
+            self.replicathreadsmanager.run()
+
+        except KeyboardInterrupt:
+            self.log.info('Caught keyboard interrupt - exitting')
+            sys.exit(0)
+        except ImportError, errorMsg:
+            self.log.error('Failed to import necessary python module: %s' % errorMsg)
+            sys.exit(0)
+        except:
+            self.log.error('Unexpected exception')
+            self.log.error(traceback.format_exc(None))
+            raise
+
+
+
+
+
+
+
+class ReplicaThreadsManager(object):
+
+    def __init__(self, oasisreplicad):
+
+        self.log = logging.getLogger('oasisreplica.replicathreadsmanager')
+        self.oasisreplicad = oasisreplicad
+        self.replicathreads = {}
+        self.log.debug('ReplicaThreadsManager object initialized')
+
+
+    def update(self):
+        '''
+        create all ReplicaThread objects
+        '''
+
+        for section in self.oasisreplicad.oasisreplicarepositoriesconf.sections():
+            if self.oasisreplicad.oasisreplicarepositoriesconf.getboolean(repo, 'enabled'):
+                replicathread = ReplicaThread(self, section)
+                self.replicathreads[section] = replicathread
+
+    def run(self):
+        '''
+        starts all ReplicaThread objects
+        '''
+
+        for repo, thread in self.replicathreads.iteritems():
+            thread.start()
+
+
+    def join(self):
+        '''
+        stops all ReplicaThread objects
+        '''
+
+        for repo, thread in self.replicathreads.iteritems():
+            thread.join()
+
+
+
+class ReplicaThread(threading.Thread):
+
+    def __init__(self, replicathreadsmanager, sectionname):
+    
+        threading.Thread.__init__(self) # init the thread
+        self.log = logging.getLogger('oasisreplica.replicathread')
+        self.stopevent = threading.Event()
+
+        self.replicathreadsmanager = replicathreadsmanager
+        self.sectionname = sectionname
+        self.reponame = self.replicathreadsmanager.oasisreplicad.oasisreplicarepositoriesconf.get(self.sectionname, 'repository')
+        self.interval = self.replicathreadsmanager.oasisreplicad.oasisreplicarepositoriesconf.getint(self.sectionname, 'interval')
+        self.ntrials = self.replicathreadsmanager.oasisreplicad.oasisreplicarepositoriesconf.getint(self.sectionname, 'ntrials')
+
+        self.log.debug('ReplicaThread object initialized')
+            
+
+    def run(self):
+
+        while not self.stopevent.isSet():
+            self.snapshot()
+            time.sleep(self.interval)
+
+    def snapshot(self):
+
+        self.log.info('to run snapshot for repo %s' %self.reponame)
+
+        if os.path.isfile('/srv/cvmfs/%s/.cvmfswhitelist' %self.reponame):  # FIXME: maybe that path should be also a config variable ???
+
+            for trial in range(self.ntrials): 
+
+                self.log.info('attempt number %s to run snapshot on %s' %(trial+1, self.reponame))
+                cmd = 'cvmfs_server snapshot %s' %self.reponame
+                self.log.info('trying command %s' %cmd)
+                before = time.time()
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+                out = None
+                (out, err) = p.communicate()
+                delta = time.time() - before
+                self.log.info('It took %s seconds to run the snapshot for %s' %(delta, self.reponame))
+                rc = p.returncode
+                if rc == 0:
+                    self.log.info('cmd %s succeeded with output %s' %(cmd, out))
+                    break
+                else:
+                    self.log.error('cmd %s failed, with err %s and rc = %s' %(cmd, err, rc))
+            else:
+                self.log.critical('snapshot for repo %s failed after %s trials' %(self.reponame, self.ntrials))
+        
+
+    def join(self,timeout=None):
+        '''
+        Stop the thread. Overriding this method required to handle Ctrl-C from console.
+        '''
+        self.stopevent.set()
+        self.log.debug('Stopping thread...')
+        threading.Thread.join(self, timeout)
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -44,15 +44,23 @@ initd_files = ['etc/oasisd',
 	       'etc/oasis-initclean',
 	       'etc/oasis-login-initclean',
 	       'etc/oasis-replica-initclean',
+
+           'etc/oasisreplicad',
 	      ]
 
 etc_files = ['etc/oasis.conf',
              'etc/projects.conf',
              'etc/repositories.conf',
              'etc/probes.conf',
+
+             'etc/oasisreplica.conf',
+             'etc/oasisreplicarepositories.conf',
             ]
 
-sysconfig_files = ['etc/sysconfig/oasis']
+sysconfig_files = ['etc/sysconfig/oasis',
+
+                   'etc/sysconfig/oasisreplica',
+                  ]
 
 logrotate_files = ['etc/logrotate/oasis']
 


### PR DESCRIPTION
[first] new code and config files for a daemon to run the snapshots at Stratum-1s via a service (daemon) instead of a cron. This first commit includes the code, two config files, the sysconfig config file, the init.d file, and the setup.py modified.
Some of the rationale (but not all reasons):
 -- based on config files
-- each repo is a separate section in the config file, so can be configured (including enabling/disabling) separately
-- it prevents 2 replica tasks from working at the same time for the same repo when a new cron cycle starts but the previous one didn't finish yet (already happened)
-- in future versions, we can randomize the time between cycles, with some back-off algorithm in case of failures. Right now it just tries N times, one after another
-- it can be started/stopped from command line, without editing the cron file
-- it runs each snapshot in a separate thread. So they are asynchronous instead of serial
-- it is in python, so it will make easier in the future to integrate other functionalities
    ---- audit the remote stratum-0 db first
    ---- run monitoring tasks
    ---- ... 

I did some tests with success. But needs to be fully tested on ITB replica. 
Idea will be to distribute this service in its own RPM. 
