### PR TITLE
avoid cvmfs_server snapshot -a with cvmfs-server-2.2.1 (OO-126)

### DIFF
--- a/goc/install/install-oasis-replica
+++ b/goc/install/install-oasis-replica
@@ -271,7 +271,9 @@ done
 mkdir -p /var/log/cvmfs
 cat >>/etc/cron.d/cvmfs <<'xEOFx'
 # Created by install script.  Will be recreated next reinstall.
-0,15,30,45 * * * * root test -d /srv/cvmfs||exit;cvmfs_server snapshot -ai
+# bug with snapshot -a in cvmfs-server-2.2.1, wait for 2.2.2 to use it
+#0,15,30,45 * * * * root test -d /srv/cvmfs||exit;cvmfs_server snapshot -ai
+0,15,30,45 * * * * root test -d /srv/cvmfs||exit;TMPFILE=/tmp/cvmfs_snapshots.$$.log;LOGFILE=/var/log/cvmfs/snapshots.log;echo "Cron log in $TMPFILE starting at `date`" >>$LOGFILE; (for r in `cd /srv/cvmfs;echo *.*`; do echo; if [ -f /srv/cvmfs/$r/.cvmfspublished ]; then echo "Starting $r at `date`";if ! cvmfs_server snapshot -t $r;then echo "ERROR from cvmfs_server!"; fi;echo "Finished $r at `date`";fi;done) >$TMPFILE 2>&1;cat $TMPFILE >>$LOGFILE;rm -f $TMPFILE
 5,20,35,50 * * * * root     (PATH=$PATH:/usr/sbin /usr/share/oasis/generate_replicas; /usr/share/oasis/replicate_whitelists) >>/var/log/cvmfs/generate_replicas.log 2>&1
 */3 * * * * root   /usr/share/oasis/oasis_replica_status >/dev/null 2>&1
 0 9 * * * root     find /srv/cvmfs/*.*/data/txn -name "*.*" -mtime +2 2>/dev/null|xargs rm -f


### PR DESCRIPTION
A bug was found in cvmfs-server-2.2.1's cvmfs_server snapshot -a command [CVM-997](https://sft.its.cern.ch/jira/browse/CVM-997) so avoid using it. Instead for now use the long cron command that does essentially the same thing and was running on hcc-cvmfs for a long time.
