### PR TITLE
Update oasis-replica install and oasis jumpstart scripts for bootstrapping

### DIFF
--- a/goc/install/install-oasis-replica
+++ b/goc/install/install-oasis-replica
@@ -128,6 +128,16 @@ yum -y --nogpg install $CVRPMS
 rm $CVRPMS
 cp /etc/cvmfs/keys/egi.eu/egi.eu.pub /etc/cvmfs/keys
 cp /etc/cvmfs/keys/opensciencegrid.org/opensciencegrid.org.pub /etc/cvmfs/keys
+if [ ! -d /srv/etc/keys ]; then
+    mkdir -p /srv/etc/keys
+    case $MYSHORTNAME in
+	*-itb)
+	    # make a copy from production
+	    SRCKEYSDIR="`echo $NETSRVDIR|sed 's/-itb//'`/etc/keys"
+	    cp $SRCKEYSDIR/* /srv/etc/keys
+	    ;;
+    esac
+fi
 yum -y install mod_wsgi
 
 echo -e "*\t\t-\tnofile\t\t16384" >>/etc/security/limits.conf

--- a/goc/install/install-oasis-replica
+++ b/goc/install/install-oasis-replica
@@ -23,6 +23,11 @@ esac
 
 set -ex
 
+# Set ITBBOOTSTRAP to true to bootstrap oasis-replica-itb from
+#   the production oasis and oasis-replica servers.  Then uninstall
+#   and reinstall without the bootstrap to correct the server URLs.
+ITBBOOTSTRAP=${ITBBOOTSTRAP:-false}
+
 SCRIPTDIR="`dirname $0`"
 if [ "$SCRIPTDIR" = "." ]; then
     SCRIPTDIR="`pwd`"
@@ -221,8 +226,13 @@ EXTRAPUBKEY=""
 case $MYSHORTNAME in
     *-itb)
 	cp "`echo $NETSRVDIR|sed 's/-replica-itb//'`"/etc/cvmfs/oasis-itb.opensciencegrid.org.pub /etc/cvmfs/keys
-	EXTRAPUBKEY="/etc/cvmfs/keys/oasis-itb.opensciencegrid.org.pub"
-	ITB="-itb"
+	if $ITBBOOTSTRAP; then
+	    ITB=""
+	    EXTRAPUBKEY="/etc/cvmfs/keys/opensciencegrid.org.pub"
+	else
+	    ITB="-itb"
+	    EXTRAPUBKEY="/etc/cvmfs/keys/oasis-itb.opensciencegrid.org.pub"
+	fi
 	;;
     *)
 	ITB=""
@@ -244,7 +254,11 @@ done
 REPOURLS="http://cvmfs-stratum0.gridpp.rl.ac.uk:8000/cvmfs/config-egi.egi.eu"
 ALLREPOURLS="$ALLREPOURLS $REPOURLS"
 for URL in $REPOURLS; do
-    add_osg_repository -a "$URL"
+    if $ITBBOOTSTRAP; then
+	add_osg_repository -a "http://oasis-replica.opensciencegrid.org:8080/cvmfs/`basename $URL`" $EXTRAPUBKEY
+    else
+	add_osg_repository -a "$URL"
+    fi
 done
 
 # Add repos registered in OIM.  It's OK if these fail because they will
@@ -252,7 +266,11 @@ done
 REPOURLS="`print_osg_repos -u`"
 ALLREPOURLS="$ALLREPOURLS $REPOURLS"
 for URL in $REPOURLS; do
-    add_osg_repository -a "$URL" || true
+    if $ITBBOOTSTRAP; then
+	add_osg_repository -a "http://oasis-replica.opensciencegrid.org:8080/cvmfs/`basename $URL`" $EXTRAPUBKEY || true
+    else
+	add_osg_repository -a "$URL" || true
+    fi
 done
 
 # make copies of .cvmfswhitelists from oasis

--- a/goc/install/jumpstart-oasis
+++ b/goc/install/jumpstart-oasis
@@ -1,13 +1,14 @@
 # /bin/bash
 # rsync oasis.opensciencegrid.org data from oasis-replica-itb to oasis-itb
 #  to jumpstart a new copy of the oasis repository.  This can save time since
-#  rebuilding oasis from scratch is a lot slower.
-# This can be run before install-oasis on a new oasis-itb, and should be
+#  rebuilding oasis from scratch is a lot slower.  At the same time, also
+#  copy config-osg.opensciencegrid.org so it can be bootstrapped.
+# This should be run before install-oasis on a new oasis-itb, and should be
 #  run when the oasis-replica-itb cvmfs cron is not running.
 # Note that normally oasis-replica-itb reads from oasis-itb, so if both
 #  oasis-replica-itb and oasis-itb need to be rebuilt from scratch, 
-#  install-oasis-replica should be altered to read temporarily from the
-#  production oasis.
+#  install-oasis-replica should set ITBBOOTSTRAP=true to read temporarily
+#  from the production oasis.
 
 set -x
 PATH=/sbin:$PATH
@@ -18,4 +19,6 @@ if [ ! -d oasis-replica-itb/cvmfs/oasis.opensciencegrid.org ]; then
 fi
 mkdir -p oasis-itb/cvmfs
 chown oasis:oasis oasis-itb/cvmfs
-runuser -s /bin/bash oasis -c "rsync -a --delete --size-only --stats oasis-replica-itb/cvmfs/oasis.opensciencegrid.org oasis-itb/cvmfs; touch oasis-itb/cvmfs/oasis.opensciencegrid.org/.cvmfs_master_replica"
+for REPO in config-osg oasis; do 
+    runuser -s /bin/bash oasis -c "rsync -a --delete --size-only --stats oasis-replica-itb/cvmfs/$REPO.opensciencegrid.org oasis-itb/cvmfs; touch oasis-itb/cvmfs/$REPO.opensciencegrid.org/.cvmfs_master_replica"
+done

--- a/goc/install/uninstall-oasis-replica
+++ b/goc/install/uninstall-oasis-replica
@@ -47,6 +47,7 @@ done
 yum -y remove httpd fuse fuse-libs cvmfs-config gdb python-anyjson python-dateutil
 rm -rf /var/log/httpd
 rm -rf /etc/cvmfs
+rm -rf /var/lib/cvmfs-server
 sed -i '/nofile.*16384/d' /etc/security/limits.conf
 rm /etc/awstats/password-file
 yum -y remove frontier-squid


### PR DESCRIPTION
Add an option ITBBOOTSTRAP to install-oasis-replica for bootstrapping from production servers, and also have it bootstrap /srv/etc/keys from the production copy if it is missing.   Change jumpstart-oasis to also copy the new config-osg repo.  Related to [OO-140](https://jira.opensciencegrid.org/browse/OO-140) and [OO-134](https://jira.opensciencegrid.org/browse/OO-134).
