### PR TITLE
oasis-goc rpm updates for November 2017

### DIFF
--- a/goc/bin/recover_oasis_rollback
+++ b/goc/bin/recover_oasis_rollback
@@ -5,7 +5,9 @@
 # Recreate .cvmfspublished & .cvmfswhitelist for oasis & config-osg repos.
 
 MASTERKEY=/etc/cvmfs/keys/oasis.opensciencegrid.org.masterkey
-if [ ! -f $MASTERKEY ] && ! cvmfs_server masterkeycard -k >/dev/null; then
+# try masterkeycard -k twice if needed, because sometimes it fails
+if [ ! -f $MASTERKEY ] && ! cvmfs_server masterkeycard -k >/dev/null &&
+        ! cvmfs_server masterkeycard -k >/dev/null; then
     echo "Only run this on the stratum 0 with the masterkey installed"
     exit 1
 fi

--- a/goc/bin/recover_oasis_rollback
+++ b/goc/bin/recover_oasis_rollback
@@ -10,13 +10,6 @@ if [ ! -f $MASTERKEY ] && ! cvmfs_server masterkeycard -k >/dev/null; then
     exit 1
 fi
 
-umountifmounted()
-{
-    if mount | grep -q " on $1"; then
-        umount $1
-    fi
-}
-
 RET=0
 set -x
 for REPO in oasis config-osg; do

--- a/goc/bin/resign_osg_whitelist
+++ b/goc/bin/resign_osg_whitelist
@@ -18,7 +18,9 @@ case $# in
 esac
 
 MASTERKEY=/etc/cvmfs/keys/oasis.opensciencegrid.org.masterkey
-if [ ! -f $MASTERKEY ] && ! cvmfs_server masterkeycard -k >/dev/null; then
+# masterkeycard access sometimes fails, so check it twice if needed
+if [ ! -f $MASTERKEY ] && ! cvmfs_server masterkeycard -k >/dev/null &&
+        ! cvmfs_server masterkeycard -k >/dev/null; then
     echo "$ME: this should only be run on the stratum 0 when the masterkey is available" >&2
     exit 1
 fi

--- a/goc/etc/httpd/conf.d/cvmfs.conf
+++ b/goc/etc/httpd/conf.d/cvmfs.conf
@@ -7,7 +7,7 @@ ListenBackLog 1024
 RewriteEngine On
 RewriteRule ^/cvmfs/info/(.*)$ /srv/cvmfs/info/$1
 RewriteRule ^/cvmfs/([^./]*)/(.*)$ /cvmfs/$1.opensciencegrid.org/$2
-RewriteRule ^/cvmfs/([^/]+)/api/(.*)$ /cvmfs/$1/api/$2 [PT]
+RewriteRule ^/cvmfs/([^/]+)/api/(.*)$ /var/www/wsgi-scripts/cvmfs-server/cvmfs-api.wsgi/$1/$2
 RewriteRule ^/cvmfs/([^/]+/.cvmfswhitelist)$ /oasissrv/cvmfs/$1
 RewriteRule ^/cvmfs/(.*)$ /srv/cvmfs/$1
 <Directory "/srv/cvmfs"> 
@@ -51,8 +51,19 @@ RewriteRule ^/cvmfs/(.*)$ /srv/cvmfs/$1
     ExpiresByType application/x-cvmfs "access plus 61 seconds"
 </Directory>
 
-WSGIDaemonProcess cvmfs-api processes=2 display-name=%{GROUP} \
-    python-path=/usr/share/cvmfs-server/webapi:/usr/share/cvmfs-servermon/webapi
-WSGIProcessGroup cvmfs-api
+# Temporarily enable cvmfs-servermon functions until it is updated
+WSGIDaemonProcess cvmfs-mon threads=16 display-name=%{GROUP} \
+    python-path=/usr/share/cvmfs-servermon/webapi
+WSGIProcessGroup cvmfs-mon
+
+# Enable the api functions
+WSGIDaemonProcess cvmfsapi threads=64 display-name=%{GROUP} \
+    python-path=/usr/share/cvmfs-server/webapi
+<Directory /var/www/wsgi-scripts/cvmfs-server>
+  WSGIProcessGroup cvmfsapi
+  WSGIApplicationGroup cvmfsapi
+  Options ExecCGI
+  SetHandler wsgi-script
+  Require all granted
+</Directory>
 WSGISocketPrefix /var/run/wsgi
-WSGIScriptAliasMatch /cvmfs/([^/]+)/api /var/www/wsgi-scripts/cvmfs-api.wsgi/$1

--- a/goc/etc/httpd/conf.d/cvmfs.conf
+++ b/goc/etc/httpd/conf.d/cvmfs.conf
@@ -51,11 +51,6 @@ RewriteRule ^/cvmfs/(.*)$ /srv/cvmfs/$1
     ExpiresByType application/x-cvmfs "access plus 61 seconds"
 </Directory>
 
-# Temporarily enable cvmfs-servermon functions until it is updated
-WSGIDaemonProcess cvmfs-mon threads=16 display-name=%{GROUP} \
-    python-path=/usr/share/cvmfs-servermon/webapi
-WSGIProcessGroup cvmfs-mon
-
 # Enable the api functions
 WSGIDaemonProcess cvmfsapi threads=64 display-name=%{GROUP} \
     python-path=/usr/share/cvmfs-server/webapi

--- a/goc/etc/httpd/conf.d/cvmfs.conf
+++ b/goc/etc/httpd/conf.d/cvmfs.conf
@@ -1,5 +1,5 @@
-# 8080 is used for other stratum 1s and 8081 is used for squid
-Listen 8080
+# 8880 is used for other stratum 1s and 8081 is used for squid
+Listen 8880
 Listen 8081
 KeepAlive On
 MaxClients 64

--- a/goc/etc/httpd/conf.d/oasis.conf
+++ b/goc/etc/httpd/conf.d/oasis.conf
@@ -1,4 +1,3 @@
-# Created by install script.  Will be recreated next reinstall.
 Listen 8000
 KeepAlive On
 MaxClients 64
@@ -24,4 +23,5 @@ RewriteRule ^/cvmfs/(.*)$ /srv/cvmfs/$1
     ExpiresDefault "access plus 3 days" 
     ExpiresByType text/html "access plus 15 minutes" 
     ExpiresByType application/x-cvmfs "access plus 61 seconds"
+    ExpiresByType application/json    "access plus 61 seconds"
 </Directory>

--- a/goc/etc/init.d/oasis-initclean
+++ b/goc/etc/init.d/oasis-initclean
@@ -1,7 +1,7 @@
 #!/bin/bash
 # /etc/rc.d/init.d/oasis-initclean
 #chkconfig: - 88 12
-#description: cleans up any leftover do_oasis_update locks, mounts cvmfs 
+#description: cleans up any leftover do_oasis_update locks, recovers rollbacks
 if [ "$1" = "start" ]; then
     LOCKPFX="/stage/locks/"
     if [ "`uname -n|cut -d. -f1`" != oasis ]; then

--- a/goc/etc/init.d/oasis-replica-initclean
+++ b/goc/etc/init.d/oasis-replica-initclean
@@ -1,0 +1,8 @@
+#!/bin/bash
+# /etc/rc.d/init.d/oasis-replica-initclean
+#chkconfig: - 88 12
+#description: cleans up any leftover .cvmfsreflog and reflog.chksum files
+if [ "$1" = "start" ]; then
+    rm -f /srv/cvmfs/*/.cvmfsreflog
+    rm -f /var/spool/cvmfs/*/reflog.chksum
+fi

--- a/goc/etc/iptables.d/60-local-cvmfs
+++ b/goc/etc/iptables.d/60-local-cvmfs
@@ -5,15 +5,17 @@
 $ITNAPRE4 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 8000
 $ITNAO4 -o lo -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 8000
 
-# open tcp port 80 and port 8000 for squid
+# open tcp port 80, 8000, and 8080 for squid
 $ITFAI -p tcp --dport 80 -j ACCEPT
 $ITFAI -p tcp --dport 8000 -j ACCEPT
+$ITFAI -p tcp --dport 8080 -j ACCEPT
 $ITFAI4 -p tcp --dport 80 -j ACCEPT
 $ITFAI4 -p tcp --dport 8000 -j ACCEPT
-
-# open tcp port 8080 for httpd
-$ITFAI -p tcp --dport 8080 -j ACCEPT
 $ITFAI4 -p tcp --dport 8080 -j ACCEPT
+
+# open tcp port 8880 for httpd
+$ITFAI -p tcp --dport 8880 -j ACCEPT
+$ITFAI4 -p tcp --dport 8880 -j ACCEPT
 
 # open udp port 3401
 $ITFAI -p udp --dport 3401 -j ACCEPT

--- a/goc/etc/squid/oasiscustomize.sh
+++ b/goc/etc/squid/oasiscustomize.sh
@@ -9,6 +9,8 @@ insertline("^http_access deny all", "cache deny !CVMFSAPI")
 # port 80 is also supported, through an iptables redirect
 setoption("http_port", "8000 accel defaultsite=localhost:8081 no-vhost")
 setoption("cache_peer", "localhost parent 8081 0 no-query originserver")
+# listen on additional port for Cloudflare CDN
+insertline("^(# |)http_port", "http_port 8080 accel defaultsite=127.0.0.1:8081 no-vhost")
 
 # allow incoming http accesses from anywhere
 # all requests will be forwarded to the originserver

--- a/goc/install/install-oasis-replica
+++ b/goc/install/install-oasis-replica
@@ -128,6 +128,7 @@ ulimit -n 16384
 
 # install oasis
 yum -y install oasis-goc oasis-goc-replica
+systemctl enable oasis-replica-initclean
 
 systemctl enable httpd
 systemctl start httpd

--- a/goc/rpm/oasis-goc.spec
+++ b/goc/rpm/oasis-goc.spec
@@ -1,6 +1,6 @@
 Summary: OASIS GOC package
 Name: oasis-goc
-Version: 2.1.27
+Version: 2.1.28
 Release: 1%{?dist} 
 Source0: %{name}-%{version}.tar.gz
 License: Apache 2.0
@@ -76,6 +76,13 @@ echo ". /etc/squid/oasiscustomize.sh"
 ) >/etc/squid/customize.sh
 chmod +x /etc/squid/customize.sh
 
+# restart apache and frontier-squid if they are active
+for service in httpd frontier-squid; do
+    if systemctl is-active --quiet $service; then
+        systemctl reload $service
+    fi
+done
+
 
 %package login
 Summary: files for OASIS login host
@@ -91,6 +98,9 @@ This package contains files for oasis-login.opensciencegrid.org
 
 
 %changelog
+* Fri Oct 20 2017 Dave Dykstra <dwd@fnal.gov> - 2.1.28-1
+- Update cvmfs.conf to go with cvmfs-2.4.2 on oasis-replica.  Reload apache
+  there if it is active, and frontier-squid too while we're at it.
 * Fri Aug 11 2017 Dave Dykstra <dwd@fnal.gov> - 2.1.27-1
 - Send oasis-login cron output to log files
 - Have copy_config_osg allow either itb or production key on oasis-itb's

--- a/goc/rpm/oasis-goc.spec
+++ b/goc/rpm/oasis-goc.spec
@@ -1,6 +1,6 @@
 Summary: OASIS GOC package
 Name: oasis-goc
-Version: 2.1.28
+Version: 2.1.29
 Release: 1%{?dist} 
 Source0: %{name}-%{version}.tar.gz
 License: Apache 2.0
@@ -59,13 +59,23 @@ This package contains files for oasis-replica.opensciencegrid.org
 
 %files replica
 /etc/cron.d/cvmfs
+/etc/init.d/oasis-replica-initclean
 /etc/squid/oasiscustomize.sh
 /etc/httpd/conf.d/cvmfs.conf
 /etc/iptables.d/60-local-cvmfs
 /etc/logrotate.d/cvmfs
 /etc/sysconfig/frontier-squid
 /var/www/html/robots.txt
+/usr/lib/systemd/system/oasis-replica-initclean.service
 %defattr(-,root,root)
+
+%post
+# restart apache and iptables if they are active
+for service in httpd iptables; do
+    if systemctl is-active --quiet $service; then
+        systemctl reload $service
+    fi
+done
 
 %post replica
 # redirect customize.sh to oasiscustomize.sh; we can't directly install
@@ -76,8 +86,8 @@ echo ". /etc/squid/oasiscustomize.sh"
 ) >/etc/squid/customize.sh
 chmod +x /etc/squid/customize.sh
 
-# restart apache and frontier-squid if they are active
-for service in httpd frontier-squid; do
+# restart apache, frontier-squid, and iptables if they are active
+for service in httpd frontier-squid iptables; do
     if systemctl is-active --quiet $service; then
         systemctl reload $service
     fi
@@ -98,6 +108,20 @@ This package contains files for oasis-login.opensciencegrid.org
 
 
 %changelog
+* Mon Nov 20 2017 Dave Dykstra <dwd@fnal.gov> - 2.1.29-1
+- Remove temporary WSGI config for cvmfs-servermon because that is now
+  built in to new version of cvmfs-servermon.
+- Add 61 second expiration of .json on stratum 0, to be consistent with
+  stratum 1.
+- Add additional listening port 8080 for squid, and move apache's port
+  for stratum 1s to 8880.
+- Reload iptables during postinstall on oasis and oasis-replica.
+- Reload httpd during postinstall on oasis as it had been on oasis-replica.
+- Run cvmfs_server masterkeycard -k twice if necessary in oasis_status_stamp,
+  resign_osg_whitelist, and recover_oasis_rollback, because sometimes the
+  key card access fails.
+- Add oasis-replica-initclean and corresponding systemd service to clean up
+  reflogs at boot time, in case of rollback.
 * Fri Oct 20 2017 Dave Dykstra <dwd@fnal.gov> - 2.1.28-1
 - Update cvmfs.conf to go with cvmfs-2.4.2 on oasis-replica.  Reload apache
   there if it is active, and frontier-squid too while we're at it.

--- a/goc/share/oasis_status_stamp
+++ b/goc/share/oasis_status_stamp
@@ -123,7 +123,8 @@ fi
 sig_age=`expr $sig_age / 86400`
 
 # check the masterkeycard availability
-cvmfs_server masterkeycard -k 1>/dev/null 2>/dev/null
+# check twice because it does fail rarely
+cvmfs_server masterkeycard -k >/dev/null 2>&1 && cvmfs_server masterkeycard -k >/dev/null 2>&1
 status=$?
 if [ $status -eq 0 ]; then
     masterkeycard_status="yes"

--- a/goc/usr/lib/systemd/system/oasis-replica-initclean.service
+++ b/goc/usr/lib/systemd/system/oasis-replica-initclean.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Oasis replica initialization boot cleanup
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/etc/init.d/oasis-replica-initclean start
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This lumps together the changes for the following tickets:
[OO-204](https://jira.opensciencegrid.org/browse/OO-204) Change resign_osg_whitelist to check for masterkeycard twice
[OO-205](https://jira.opensciencegrid.org/browse/OO-205) Upgrade oasis and oasis-replica to cvmfs-2.4.2+
[OO-209](https://jira.opensciencegrid.org/browse/OO-209) Update oasis-replica to cvmfs-servermon-1.5+
[OO-210](https://jira.opensciencegrid.org/browse/OO-210) Add additional listening port of 8080 for squid on oasis-replica
[OO-211](https://jira.opensciencegrid.org/browse/OO-211) oasis & oasis-replica should remove .cvmfsreflog and reflog.chksum at boot