### PR TITLE
add GATech cache to (non)auth; remove UChicago and UNL from non-auth …

### DIFF
--- a/goc/config-osg/etc/cvmfs/config.d/ligo.osgstorage.org.conf
+++ b/goc/config-osg/etc/cvmfs/config.d/ligo.osgstorage.org.conf
@@ -1,4 +1,4 @@
-CVMFS_EXTERNAL_URL="https://xrootd-local.unl.edu:1094//user/ligo/;https://its-condor-xrootd1.syr.edu:8443//user/ligo/;https://osg-kansas-city-stashcache.nrp.internet2.edu:8444//user/ligo/;https://osg-chicago-stashcache.nrp.internet2.edu:8444//user/ligo/;https://osg-new-york-stashcache.nrp.internet2.edu:8444//user/ligo/"
+CVMFS_EXTERNAL_URL="https://xrootd-local.unl.edu:1094//user/ligo/;https://its-condor-xrootd1.syr.edu:8443//user/ligo/;https://osg-kansas-city-stashcache.nrp.internet2.edu:8444//user/ligo/;https://osg-chicago-stashcache.nrp.internet2.edu:8444//user/ligo/;https://osg-new-york-stashcache.nrp.internet2.edu:8444//user/ligo/;http://osg-gftp.pace.gatech.edu:8443//user/ligo/"
 
 # need to set these to anything here to export them from this config file
 CVMFS_AUTHZ_OSG_BASE_DIR=

--- a/goc/config-osg/etc/cvmfs/domain.d/osgstorage.org.conf
+++ b/goc/config-osg/etc/cvmfs/domain.d/osgstorage.org.conf
@@ -4,7 +4,7 @@ if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ]; then
 else
     CVMFS_SERVER_URL="http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1goc.opensciencegrid.org/cvmfs/@fqrn@"
 fi
-CVMFS_EXTERNAL_URL="http://hcc-stash.unl.edu:8000/;http://osgxroot.usatlas.bnl.gov:8000/;http://stashcache.grid.uchicago.edu:8000/;http://xrd-cache-1.t2.ucsd.edu:8000/;http://mwt2-stashcache.campuscluster.illinois.edu:8000/;http://its-condor-xrootd1.syr.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://fiona.uvalight.net:8000/;http://osg-chicago-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://sc-cache.chtc.wisc.edu:8000/"
+CVMFS_EXTERNAL_URL="http://osgxroot.usatlas.bnl.gov:8000/;http://xrd-cache-1.t2.ucsd.edu:8000/;http://mwt2-stashcache.campuscluster.illinois.edu:8000/;http://its-condor-xrootd1.syr.edu:8000/;http://osg-kansas-city-stashcache.nrp.internet2.edu:8000/;http://fiona.uvalight.net:8000/;http://osg-chicago-stashcache.nrp.internet2.edu:8000/;http://osg-new-york-stashcache.nrp.internet2.edu:8000/;http://sc-cache.chtc.wisc.edu:8000/;http://osg-gftp.pace.gatech.edu:8000/"
 CVMFS_FOLLOW_REDIRECTS=yes
 CVMFS_QUOTA_LIMIT=1000
 CVMFS_CACHE_BASE="$CVMFS_CACHE_BASE/osgstorage"


### PR DESCRIPTION
* add GATech cache to non-authenticated list of caches and LIGO authenticated (STAS-51)
* remove UChicago and UNL cache from URL list as they subscribe directly to redirectors (STAS-52)