### PR TITLE
remove installing engine_pkcs11

### DIFF
--- a/goc/install/install-oasis
+++ b/goc/install/install-oasis
@@ -84,7 +84,7 @@ for LOGD in oasis httpd; do
 done
 
 # install cvmfs
-yum -y install cvmfs cvmfs-server cvmfs-servermon opensc yubico-piv-tool engine_pkcs11
+yum -y install cvmfs cvmfs-server cvmfs-servermon opensc yubico-piv-tool
 systemctl enable pcscd.socket
 systemctl start pcscd.socket
 cp /etc/cvmfs/keys/opensciencegrid.org/opensciencegrid.org.pub /etc/cvmfs/keys


### PR DESCRIPTION
This is no longer needed now that cvmfs-server-2.6.1 is using a lower-level library.