### PR TITLE
add test to compare actual github source with config-osg repo

### DIFF
--- a/goc/bin/copy_config_osg
+++ b/goc/bin/copy_config_osg
@@ -45,7 +45,6 @@ confirm()
 if [[ $(hostname -s) = *-itb ]]; then
     # run only if non-root
     if ! [ $(id -u) = 0 ]; then
-
         if git remote -v 2>/dev/null | grep -q /config-repo.git; then
             current_dir="$(git rev-parse --show-toplevel)"
             cd ${current_dir}
@@ -54,6 +53,7 @@ if [[ $(hostname -s) = *-itb ]]; then
         else
             >&2 echo "Make sure you're in config-repo.git repo directory, exiting..."
             exit 1
+        fi
     else
         # exit if /opt/config-repo/ doesn't exist
         if ! cd /opt/config-repo/ &>/dev/null; then

--- a/goc/bin/copy_config_osg
+++ b/goc/bin/copy_config_osg
@@ -49,6 +49,7 @@ if [[ $(hostname -s) = *-itb ]]; then
             current_dir="$(git rev-parse --show-toplevel)"
             set -ex
             cd ${current_dir}
+            get_branch
             if [[ ${current_branch_name} == "osg" ]]; then
                 git pull upstream osg
                 rsync -av /cvmfs/config-osg.opensciencegrid.org ${current_dir}

--- a/goc/bin/copy_config_osg
+++ b/goc/bin/copy_config_osg
@@ -41,36 +41,41 @@ confirm()
     esac
 }
 
-# run only on -itb host if non-root
-if [[ $(hostname -s) = *-itb && $(id -u) != 0 ]]; then
+# run only on -itb host 
+if [[ $(hostname -s) = *-itb ]]; then
+    # run only if non-root
+    if ! [ $(id -u) = 0 ]; then
 
-    inside_git_repo="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
-
-    if [ "$inside_git_repo" ]; then
-        current_dir=`pwd`
+        if git remote -v 2>/dev/null | grep -q /config-repo.git; then
+            current_dir="$(git rev-parse --show-toplevel)"
+            cd ${current_dir}
+            git pull upstream osg
+            rsync -av /cvmfs/config-osg.opensciencegrid.org ${current_dir}
+        else
+            >&2 echo "Make sure you're in config-repo.git repo directory, exiting..."
+            exit 1
+    else
+        # exit if /opt/config-repo/ doesn't exist
+        if ! cd /opt/config-repo/ &>/dev/null; then
+            >&2 echo "/opt/config-repo doesn't exist, exiting..."
+            exit 1
+        fi
         get_branch
         # make sure osg branch is set
         if [[ ${current_branch_name} != "osg" ]]; then
-            echo "Make sure to checkout osg branch, exiting..."
-            exit 1
+            git checkout osg
         fi
-        git pull &>/dev/null
-    else
-        >&2 echo "Make sure you're in .git repo directory, exiting..."
-        exit 1
-    fi
-
-    # exit if config directory is different from github source
-    if ! diff -q -r /cvmfs/config-osg.opensciencegrid.org/ ${current_dir} --exclude=.git &>/dev/null; then
-        >&2 echo "Config directories:"
-        >&2 echo "   /cvmfs/config-osg.opensciencegrid.org/"
-        >&2 echo "and"
-        >&2 echo "   ${current_dir}"
-        >&2 echo "are different! Make sure to submit PR with changes first, exiting..."
-        exit 1
+        git pull
+        rsync -av /cvmfs/config-osg.opensciencegrid.org $(git rev-parse --show-toplevel)
     fi
 
 else
+
+    if ! [ $(id -u) = 0 ]; then
+       echo "I am not root!"
+       exit 1
+    fi
+
     set -ex
     mkdir -p /cvmfs/config-osg-itb.opensciencegrid.org /etc/cvmfs/config.d
     cat >/etc/cvmfs/config.d/config-osg.opensciencegrid.org.local <<!EOF!
@@ -95,19 +100,18 @@ else
 
     # make sure osg branch is set
     if [[ ${current_branch_name} != "osg" ]]; then
-        echo "Make sure to checkout osg branch, exiting..."
-        exit 1
+        git checkout osg
     fi
 
-    git pull &>/dev/null
+    git pull
 
-    if ! diff -q -r /cvmfs/config-osg.opensciencegrid.org/ /opt/config-repo --exclude=.git &>/dev/null; then
+    if ! diff -q -r /cvmfs/config-osg-itb.opensciencegrid.org/ /opt/config-repo --exclude=.git &>/dev/null; then
         >&2 echo "Config directories:"
         >&2 echo "   /cvmfs/config-osg-itb.opensciencegrid.org/"
         >&2 echo "and"
         >&2 echo "   /opt/config-repo"
         >&2 echo "are different! Meaning .git changes didn't catch up yet..."
-        confirm "Would you really like to continue?" && exit 1
+        confirm "Would you really like to continue? [y/N]" && exit 1
     fi
 
     rsync -av --delete /cvmfs/config-osg-itb.opensciencegrid.org/ /cvmfs/config-osg.opensciencegrid.org

--- a/goc/bin/copy_config_osg
+++ b/goc/bin/copy_config_osg
@@ -49,8 +49,13 @@ if [[ $(hostname -s) = *-itb ]]; then
             current_dir="$(git rev-parse --show-toplevel)"
             set -ex
             cd ${current_dir}
-            git pull upstream osg
-            rsync -av /cvmfs/config-osg.opensciencegrid.org ${current_dir}
+            if [[ ${current_branch_name} == "osg" ]]; then
+                git pull upstream osg
+                rsync -av /cvmfs/config-osg.opensciencegrid.org ${current_dir}
+            else
+                >&2 echo "You are on the ${current_branch_name} branch, please swith to the osg, exiting..."
+                exit 1
+            fi
         else
             >&2 echo "Make sure to git clone config-repo.git and you're inside the repo directory, exiting..."
             exit 1
@@ -66,14 +71,13 @@ else
        echo "I am not root!"
        exit 1
     fi
-
-    set -ex
     # exit if /opt/config-repo/ doesn't exist
     if ! cd /opt/config-repo/ &>/dev/null; then
         >&2 echo "/opt/config-repo doesn't exist, exiting..."
         exit 1
     fi
 
+    set -ex
     mkdir -p /cvmfs/config-osg-itb.opensciencegrid.org /etc/cvmfs/config.d
     cat >/etc/cvmfs/config.d/config-osg.opensciencegrid.org.local <<!EOF!
     CVMFS_SERVER_URL=http://oasis-itb.opensciencegrid.org:8000/cvmfs/@fqrn@

--- a/goc/bin/copy_config_osg
+++ b/goc/bin/copy_config_osg
@@ -47,12 +47,12 @@ if [[ $(hostname -s) = *-itb ]]; then
     if ! [ $(id -u) = 0 ]; then
         if git remote -v 2>/dev/null | grep -q /config-repo.git; then
             current_dir="$(git rev-parse --show-toplevel)"
+            get_branch
             set -ex
             cd ${current_dir}
-            get_branch
-            if [[ ${current_branch_name} == "osg" ]]; then
+            if [ ${current_branch_name} == "osg" ]; then
                 git pull upstream osg
-                rsync -av /cvmfs/config-osg.opensciencegrid.org ${current_dir}
+                rsync -avc /cvmfs/config-osg.opensciencegrid.org/ ${current_dir}
             else
                 >&2 echo "You are on the ${current_branch_name} branch, please switch to the osg, exiting..."
                 exit 1
@@ -78,39 +78,48 @@ else
         exit 1
     fi
 
-    set -ex
-    mkdir -p /cvmfs/config-osg-itb.opensciencegrid.org /etc/cvmfs/config.d
-    cat >/etc/cvmfs/config.d/config-osg.opensciencegrid.org.local <<!EOF!
-    CVMFS_SERVER_URL=http://oasis-itb.opensciencegrid.org:8000/cvmfs/@fqrn@
-    CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/opensciencegrid.org.pub:/srv/etc/cvmfs/oasis-itb.opensciencegrid.org.pub
-    CVMFS_HTTP_PROXY=DIRECT
-    unset CVMFS_CONFIG_REPOSITORY
-    !EOF!
-    mount -t cvmfs config-osg.opensciencegrid.org /cvmfs/config-osg-itb.opensciencegrid.org
-    if ! cvmfs_server transaction config-osg.opensciencegrid.org; then
-        cvmfs_server abort -f config-osg.opensciencegrid.org
-        cvmfs_server transaction config-osg.opensciencegrid.org
-    fi
-
     get_branch
-
     # make sure osg branch is set
-    if [[ ${current_branch_name} != "osg" ]]; then
+    if [ ${current_branch_name} != "osg" ]; then
         git checkout osg
     fi
 
+    set -ex
+    cd $PWD  # just to show the user the directory
     git pull
 
+    mkdir -p /cvmfs/config-osg-itb.opensciencegrid.org /etc/cvmfs/config.d
+    cat >/etc/cvmfs/config.d/config-osg.opensciencegrid.org.local <<!EOF!
+CVMFS_SERVER_URL=http://oasis-itb.opensciencegrid.org:8000/cvmfs/@fqrn@
+CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/opensciencegrid.org.pub:/srv/etc/cvmfs/oasis-itb.opensciencegrid.org.pub
+CVMFS_HTTP_PROXY=DIRECT
+unset CVMFS_CONFIG_REPOSITORY
+!EOF!
+    mount -t cvmfs config-osg.opensciencegrid.org /cvmfs/config-osg-itb.opensciencegrid.org
+
     if ! diff -q -r /cvmfs/config-osg-itb.opensciencegrid.org/ /opt/config-repo --exclude=.git &>/dev/null; then
+	set +x
         >&2 echo "Config directories:"
         >&2 echo "   /cvmfs/config-osg-itb.opensciencegrid.org/"
         >&2 echo "and"
         >&2 echo "   /opt/config-repo"
         >&2 echo "are different! Meaning .git changes didn't catch up yet..."
-        confirm "Would you really like to continue? [y/N]" && exit 1
+        if confirm "Would you really like to continue? [y/N]"; then
+	    set -x
+	    umount /cvmfs/config-osg-itb.opensciencegrid.org
+	    rm /etc/cvmfs/config.d/config-osg.opensciencegrid.org.local
+	    rmdir /cvmfs/config-osg-itb.opensciencegrid.org
+	    exit 1
+	fi
+	set -x
     fi
 
-    rsync -av --delete /cvmfs/config-osg-itb.opensciencegrid.org/ /cvmfs/config-osg.opensciencegrid.org
+    if ! cvmfs_server transaction config-osg.opensciencegrid.org; then
+        cvmfs_server abort -f config-osg.opensciencegrid.org
+        cvmfs_server transaction config-osg.opensciencegrid.org
+    fi
+
+    rsync -avc --delete /cvmfs/config-osg-itb.opensciencegrid.org/ /cvmfs/config-osg.opensciencegrid.org
     umount /cvmfs/config-osg-itb.opensciencegrid.org
     rm /etc/cvmfs/config.d/config-osg.opensciencegrid.org.local
     rmdir /cvmfs/config-osg-itb.opensciencegrid.org

--- a/goc/bin/copy_config_osg
+++ b/goc/bin/copy_config_osg
@@ -18,21 +18,52 @@ if [ ! -f /etc/cvmfs/repositories.d/config-osg.opensciencegrid.org/client.conf ]
     exit 1
 fi
 
-set -ex
-mkdir -p /cvmfs/config-osg-itb.opensciencegrid.org /etc/cvmfs/config.d
-cat >/etc/cvmfs/config.d/config-osg.opensciencegrid.org.local <<!EOF!
-CVMFS_SERVER_URL=http://oasis-itb.opensciencegrid.org:8000/cvmfs/@fqrn@
-CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/opensciencegrid.org.pub:/srv/etc/cvmfs/oasis-itb.opensciencegrid.org.pub
-CVMFS_HTTP_PROXY=DIRECT
-unset CVMFS_CONFIG_REPOSITORY
-!EOF!
-mount -t cvmfs config-osg.opensciencegrid.org /cvmfs/config-osg-itb.opensciencegrid.org
-if ! cvmfs_server transaction config-osg.opensciencegrid.org; then
-    cvmfs_server abort -f config-osg.opensciencegrid.org
-    cvmfs_server transaction config-osg.opensciencegrid.org
+if [[ $(hostname -s) = *-itb ]]; then
+    # exit if /opt/config-repo/ doesn't exist
+    if ! cd /opt/config-repo/ &>/dev/null; then
+        >&2 echo "/opt/config-repo doesn't exist, exiting..."
+        exit 1
+    fi
+
+    # get branch name
+    raw_current_branch=`git branch | grep "*"`
+    current_branch=${raw_current_branch#* }
+    # get last component of branch name
+    current_branch_name=${current_branch##*\/}
+
+    if [[ ${current_branch_name} != "osg" ]]; then
+        echo "Make sure to checkout osg branch, exiting..."
+        exit 1
+    fi
+
+    git pull &>/dev/null
+
+    # exit if config directory is different from github source
+    if ! diff -q -r /cvmfs/config-osg.opensciencegrid.org/ /opt/config-repo/ --exclude=.git &>/dev/null; then
+        >&2 echo "config directories:"
+        >&2 echo "   /cvmfs/config-osg.opensciencegrid.org/"
+        >&2 echo "and"
+        >&2 echo "   /opt/config-repo/"
+        >&2 echo "are different! Exiting..."
+        exit 1
+    fi
+else
+    set -ex
+    mkdir -p /cvmfs/config-osg-itb.opensciencegrid.org /etc/cvmfs/config.d
+    cat >/etc/cvmfs/config.d/config-osg.opensciencegrid.org.local <<!EOF!
+    CVMFS_SERVER_URL=http://oasis-itb.opensciencegrid.org:8000/cvmfs/@fqrn@
+    CVMFS_PUBLIC_KEY=/etc/cvmfs/keys/opensciencegrid.org.pub:/srv/etc/cvmfs/oasis-itb.opensciencegrid.org.pub
+    CVMFS_HTTP_PROXY=DIRECT
+    unset CVMFS_CONFIG_REPOSITORY
+    !EOF!
+    mount -t cvmfs config-osg.opensciencegrid.org /cvmfs/config-osg-itb.opensciencegrid.org
+    if ! cvmfs_server transaction config-osg.opensciencegrid.org; then
+        cvmfs_server abort -f config-osg.opensciencegrid.org
+        cvmfs_server transaction config-osg.opensciencegrid.org
+    fi
+    rsync -av --delete /cvmfs/config-osg-itb.opensciencegrid.org/ /cvmfs/config-osg.opensciencegrid.org
+    umount /cvmfs/config-osg-itb.opensciencegrid.org
+    rm /etc/cvmfs/config.d/config-osg.opensciencegrid.org.local
+    rmdir /cvmfs/config-osg-itb.opensciencegrid.org
+    cvmfs_server publish config-osg.opensciencegrid.org
 fi
-rsync -av --delete /cvmfs/config-osg-itb.opensciencegrid.org/ /cvmfs/config-osg.opensciencegrid.org
-umount /cvmfs/config-osg-itb.opensciencegrid.org
-rm /etc/cvmfs/config.d/config-osg.opensciencegrid.org.local
-rmdir /cvmfs/config-osg-itb.opensciencegrid.org
-cvmfs_server publish config-osg.opensciencegrid.org

--- a/goc/bin/copy_config_osg
+++ b/goc/bin/copy_config_osg
@@ -47,26 +47,17 @@ if [[ $(hostname -s) = *-itb ]]; then
     if ! [ $(id -u) = 0 ]; then
         if git remote -v 2>/dev/null | grep -q /config-repo.git; then
             current_dir="$(git rev-parse --show-toplevel)"
+            set -ex
             cd ${current_dir}
             git pull upstream osg
             rsync -av /cvmfs/config-osg.opensciencegrid.org ${current_dir}
         else
-            >&2 echo "Make sure you're in config-repo.git repo directory, exiting..."
+            >&2 echo "Make sure to git clone config-repo.git and you're inside the repo directory, exiting..."
             exit 1
         fi
     else
-        # exit if /opt/config-repo/ doesn't exist
-        if ! cd /opt/config-repo/ &>/dev/null; then
-            >&2 echo "/opt/config-repo doesn't exist, exiting..."
-            exit 1
-        fi
-        get_branch
-        # make sure osg branch is set
-        if [[ ${current_branch_name} != "osg" ]]; then
-            git checkout osg
-        fi
-        git pull
-        rsync -av /cvmfs/config-osg.opensciencegrid.org $(git rev-parse --show-toplevel)
+        >&2 echo "Make sure to run ${ME} as non-root, exiting..."
+        exit 1
     fi
 
 else
@@ -77,6 +68,12 @@ else
     fi
 
     set -ex
+    # exit if /opt/config-repo/ doesn't exist
+    if ! cd /opt/config-repo/ &>/dev/null; then
+        >&2 echo "/opt/config-repo doesn't exist, exiting..."
+        exit 1
+    fi
+
     mkdir -p /cvmfs/config-osg-itb.opensciencegrid.org /etc/cvmfs/config.d
     cat >/etc/cvmfs/config.d/config-osg.opensciencegrid.org.local <<!EOF!
     CVMFS_SERVER_URL=http://oasis-itb.opensciencegrid.org:8000/cvmfs/@fqrn@
@@ -88,12 +85,6 @@ else
     if ! cvmfs_server transaction config-osg.opensciencegrid.org; then
         cvmfs_server abort -f config-osg.opensciencegrid.org
         cvmfs_server transaction config-osg.opensciencegrid.org
-    fi
-
-    # exit if /opt/config-repo/ doesn't exist
-    if ! cd /opt/config-repo/ &>/dev/null; then
-        >&2 echo "/opt/config-repo doesn't exist, exiting..."
-        exit 1
     fi
 
     get_branch

--- a/goc/bin/copy_config_osg
+++ b/goc/bin/copy_config_osg
@@ -18,35 +18,58 @@ if [ ! -f /etc/cvmfs/repositories.d/config-osg.opensciencegrid.org/client.conf ]
     exit 1
 fi
 
-if [[ $(hostname -s) = *-itb ]]; then
-    # exit if /opt/config-repo/ doesn't exist
-    if ! cd /opt/config-repo/ &>/dev/null; then
-        >&2 echo "/opt/config-repo doesn't exist, exiting..."
-        exit 1
-    fi
-
+get_branch()
+{
     # get branch name
     raw_current_branch=`git branch | grep "*"`
     current_branch=${raw_current_branch#* }
     # get last component of branch name
     current_branch_name=${current_branch##*\/}
+}
 
-    if [[ ${current_branch_name} != "osg" ]]; then
-        echo "Make sure to checkout osg branch, exiting..."
+confirm() 
+{
+    # call with a prompt string or use a default
+    read -r -p "${1:-Are you sure? [y/N]} " response
+    case "$response" in
+        [yY][eE][sS]|[yY]) 
+            false
+            ;;
+        *)
+            true
+            ;;
+    esac
+}
+
+# run only on -itb host if non-root
+if [[ $(hostname -s) = *-itb && $(id -u) != 0 ]]; then
+
+    inside_git_repo="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
+
+    if [ "$inside_git_repo" ]; then
+        current_dir=`pwd`
+        get_branch
+        # make sure osg branch is set
+        if [[ ${current_branch_name} != "osg" ]]; then
+            echo "Make sure to checkout osg branch, exiting..."
+            exit 1
+        fi
+        git pull &>/dev/null
+    else
+        >&2 echo "Make sure you're in .git repo directory, exiting..."
         exit 1
     fi
-
-    git pull &>/dev/null
 
     # exit if config directory is different from github source
-    if ! diff -q -r /cvmfs/config-osg.opensciencegrid.org/ /opt/config-repo/ --exclude=.git &>/dev/null; then
-        >&2 echo "config directories:"
+    if ! diff -q -r /cvmfs/config-osg.opensciencegrid.org/ ${current_dir} --exclude=.git &>/dev/null; then
+        >&2 echo "Config directories:"
         >&2 echo "   /cvmfs/config-osg.opensciencegrid.org/"
         >&2 echo "and"
-        >&2 echo "   /opt/config-repo/"
-        >&2 echo "are different! Exiting..."
+        >&2 echo "   ${current_dir}"
+        >&2 echo "are different! Make sure to submit PR with changes first, exiting..."
         exit 1
     fi
+
 else
     set -ex
     mkdir -p /cvmfs/config-osg-itb.opensciencegrid.org /etc/cvmfs/config.d
@@ -61,6 +84,32 @@ else
         cvmfs_server abort -f config-osg.opensciencegrid.org
         cvmfs_server transaction config-osg.opensciencegrid.org
     fi
+
+    # exit if /opt/config-repo/ doesn't exist
+    if ! cd /opt/config-repo/ &>/dev/null; then
+        >&2 echo "/opt/config-repo doesn't exist, exiting..."
+        exit 1
+    fi
+
+    get_branch
+
+    # make sure osg branch is set
+    if [[ ${current_branch_name} != "osg" ]]; then
+        echo "Make sure to checkout osg branch, exiting..."
+        exit 1
+    fi
+
+    git pull &>/dev/null
+
+    if ! diff -q -r /cvmfs/config-osg.opensciencegrid.org/ /opt/config-repo --exclude=.git &>/dev/null; then
+        >&2 echo "Config directories:"
+        >&2 echo "   /cvmfs/config-osg-itb.opensciencegrid.org/"
+        >&2 echo "and"
+        >&2 echo "   /opt/config-repo"
+        >&2 echo "are different! Meaning .git changes didn't catch up yet..."
+        confirm "Would you really like to continue?" && exit 1
+    fi
+
     rsync -av --delete /cvmfs/config-osg-itb.opensciencegrid.org/ /cvmfs/config-osg.opensciencegrid.org
     umount /cvmfs/config-osg-itb.opensciencegrid.org
     rm /etc/cvmfs/config.d/config-osg.opensciencegrid.org.local

--- a/goc/bin/copy_config_osg
+++ b/goc/bin/copy_config_osg
@@ -54,7 +54,7 @@ if [[ $(hostname -s) = *-itb ]]; then
                 git pull upstream osg
                 rsync -av /cvmfs/config-osg.opensciencegrid.org ${current_dir}
             else
-                >&2 echo "You are on the ${current_branch_name} branch, please swith to the osg, exiting..."
+                >&2 echo "You are on the ${current_branch_name} branch, please switch to the osg, exiting..."
                 exit 1
             fi
         else

--- a/goc/rpm/oasis-goc.spec
+++ b/goc/rpm/oasis-goc.spec
@@ -1,6 +1,6 @@
 Summary: OASIS GOC package
 Name: oasis-goc
-Version: 2.2.8
+Version: 2.2.9
 Release: 1%{?dist} 
 Source0: %{name}-%{version}.tar.gz
 License: Apache 2.0
@@ -11,7 +11,7 @@ BuildArch: noarch
 Url: http://www.opensciencegrid.org
 
 %description
-This package contains OASIS software for the OSG Global Operations Center
+This package contains OASIS software for the OSG Operations
 
 %prep
 %setup -q
@@ -105,7 +105,12 @@ This package contains files for oasis-login.opensciencegrid.org
 
 
 %changelog
-# - Remove references to cvmfs-snapshot in {add|remove}_osg_repository
+* Thu Aug 29 2019 Marian Zvada <marian.zvada@cern.ch> - 2.2.9-1
+- Remove references to cvmfs-snapshot in {add|remove}_osg_repository
+- Add test to compare current github source with config-osg repo 
+  to copy_config_osg (OO-236) 
+- Add functionality to copy_config_osg that assists with submitting 
+  a PR for changes to the config-osg repo on the -itb host
 
 * Fri Jun 28 2019 Dave Dykstra <dwd@fnal.gov> - 2.2.8-1
 - Update cron to run do_du daily (OO-267)


### PR DESCRIPTION
Pull latest osg branch of config-repo and compare with actual configuration in /cvmfs/config-osg.opensciencegrid.org/. Applies to the `-itb` host(s) only.