### PR TITLE
Limit snapshots on stratum 1 to the number of cores

### DIFF
--- a/goc/etc/cron.d/cvmfs
+++ b/goc/etc/cron.d/cvmfs
@@ -1,7 +1,7 @@
-* * * * * root test -f /var/lib/oasis/installed && cvmfs_server snapshot -ais
-* * * * * root test -f /var/lib/oasis/installed && sleep 15 && cvmfs_server snapshot -ais
-* * * * * root test -f /var/lib/oasis/installed && sleep 30 && cvmfs_server snapshot -ais
-* * * * * root test -f /var/lib/oasis/installed && sleep 45 && cvmfs_server snapshot -ais
+* * * * * root test -f /var/lib/oasis/installed && sem --id snapshot -j +0 --st -1 cvmfs_server snapshot -ais 2>/dev/null || true
+* * * * * root test -f /var/lib/oasis/installed && sleep 15 && sem --id snapshot -j +0 --st -1 cvmfs_server snapshot -ais 2>/dev/null || true
+* * * * * root test -f /var/lib/oasis/installed && sleep 30 && sem --id snapshot -j +0 --st -1 cvmfs_server snapshot -ais 2>/dev/null || true
+* * * * * root test -f /var/lib/oasis/installed && sleep 45 && sem --id snapshot -j +0 --st -1 cvmfs_server snapshot -ais 2>/dev/null || true
 8,23,38,53 * * * * root test -f /var/lib/oasis/installed && (PATH=$PATH:/usr/sbin:/usr/share/oasis; generate_replicas; replicate_whitelists) >>/var/log/cvmfs/generate_replicas.log 2>&1
 */3 * * * * root /usr/share/oasis/oasis_replica_status >/dev/null 2>&1
 8 5 * * * root test -f /var/lib/oasis/installed && cvmfs_server gc -af

--- a/goc/rpm/oasis-goc.spec
+++ b/goc/rpm/oasis-goc.spec
@@ -55,6 +55,7 @@ Summary: files for OASIS stratum one
 Group: Development/Libraries
 %description replica
 This package contains files for oasis-replica.opensciencegrid.org
+Requires: parallel
 
 %files replica
 /etc/cron.d/cvmfs
@@ -105,6 +106,8 @@ This package contains files for oasis-login.opensciencegrid.org
 
 
 %changelog
+#- Limit parallel snapshots on stratum 1 to the number of cores
+
 * Tue May 05 2020 Dave Dykstra <dwd@fnal.gov> - 2.2.11-1
 - Add list of cms servers to make_stashservers_list.
 


### PR DESCRIPTION
This has already been running on oasis-replica-itb for quite some time, because we had cases where snapshots got stuck and caused too much parallelism.