### PR TITLE
Convert from libxml2 to lxml, update to 3.10

### DIFF
--- a/bin/print_osg_repos
+++ b/bin/print_osg_repos
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import urllib.request, urllib.error, urllib.parse
-import libxml2
+from lxml import etree
 import sys
 
 printurls = False
@@ -11,12 +11,12 @@ elif len(sys.argv) != 1:
     sys.exit("Usage: print_osg_repos [-u]")
 
 response = urllib.request.urlopen("https://topology.opensciencegrid.org/vosummary/xml?summary_attrs_showoasis=on&all_vos=on&active=on&active_value=1&sort_key=name", timeout=30)
-xml = response.read().decode(response.headers.get_content_charset(failobj='utf-8'))
-doc = libxml2.parseDoc(xml)
+xml = response.read()
+doc = etree.XML(xml)
 
 repos = []
-for urlfield in doc.xpathEval("//VO/OASIS/OASISRepoURLs/URL"):
-    url = urlfield.content
+for urlfield in doc.xpath("//VO/OASIS/OASISRepoURLs/URL"):
+    url = urlfield.text
     if url[-1] == '/':
       # remove a trailing slash
       url = url[:-1]

--- a/rpm/oasis-server.spec
+++ b/rpm/oasis-server.spec
@@ -1,6 +1,6 @@
 Summary: OASIS server package
 Name: oasis-server
-Version: 3.9
+Version: 3.10
 Release: 1%{?dist} 
 Source0: %{name}-%{version}.tar.gz
 License: Apache 2.0
@@ -9,6 +9,7 @@ BuildArch: noarch
 Url: http://www.opensciencegrid.org
 
 Obsoletes: oasis-goc
+Requires: python3-lxml
 
 %description
 This package contains OASIS server software for OSG Operations
@@ -39,6 +40,7 @@ rm -rf $RPM_BUILD_ROOT
 Summary: files for OASIS stratum zero
 Group: Development/Libraries
 
+Requires: oasis-server = %{version}-%{release}
 Obsoletes: oasis-goc-zero
 
 # Require specific versions of packages from osg yum repo so 
@@ -63,9 +65,9 @@ This package contains files for oasis.opensciencegrid.org
 Summary: files for OASIS stratum one
 Group: Development/Libraries
 
+Requires: oasis-server = %{version}-%{release}
 Requires: cvmfs-manage-replicas
 Obsoletes: oasis-goc-replica
-Requires: python3-lxml
 
 # Require specific versions of packages from osg yum repo so 
 #  they can't be upgraded without being tested first on itb
@@ -120,6 +122,7 @@ done
 Summary: files for OASIS login host
 Group: Development/Libraries
 
+Requires: oasis-server = %{version}-%{release}
 Obsoletes: oasis-goc-login
 
 %description login
@@ -132,6 +135,12 @@ This package contains files for oasis-login.opensciencegrid.org
 
 
 %changelog
+* Thu Mar 23 2023 Dave Dykstra <dwd@fnal.gov> - 3.10-1
+- Make python3 usable on both el7 & el8 by converting python tools from
+  libxml2 to lxml.
+- Require python3-lxml on all hosts.
+- Make each of the subpackages require the main package.
+
 * Tue Mar 21 2023 Dave Dykstra <dwd@fnal.gov> - 3.9-1
 - Update cvmfs & cvmfs-server to 2.10.1, including removing the use
   of the sem command for snapshots since limiting parallelism is 

--- a/share/generate_adduser
+++ b/share/generate_adduser
@@ -1,20 +1,20 @@
 #!/usr/bin/python3
 
 import urllib.request
-import libxml2
+from lxml import etree
 import sys
 import re
 
 #download vosummary (for oasis enabled)
 response = urllib.request.urlopen("https://topology.opensciencegrid.org/vosummary/xml?summary_attrs_showoasis=on&all_vos=on&active=on&active_value=1&oasis=on&oasis_value=1&sort_key=name", timeout=30)
-xml = response.read().decode(response.headers.get_content_charset(failobj='utf-8'))
-doc = libxml2.parseDoc(xml)
+xml = response.read()
+doc = etree.XML(xml)
 
 #parse out the VO names
-for vo in doc.xpathEval("//VO"):
+for vo in doc.xpath("//VO"):
 
         #create good unixname
-        voname = vo.xpathEval("Name")[0].content
+        voname = vo.xpath("Name")[0].text
         voname = re.sub(r'[^/a-z0-9]+', '', voname.lower())
 
         username = "ouser."+voname

--- a/share/generate_gridmap
+++ b/share/generate_gridmap
@@ -1,28 +1,28 @@
 #!/usr/bin/python3
 
 import urllib.request
-import libxml2
+from lxml import etree
 import sys
 import re
 
 #download vosummary (for oasis enabled)
 response = urllib.request.urlopen("https://topology.opensciencegrid.org/vosummary/xml?summary_attrs_showoasis=on&all_vos=on&active=on&active_value=1&oasis=on&oasis_value=1&sort_key=name", timeout=30)
-xml = response.read().decode(response.headers.get_content_charset(failobj='utf-8'))
-doc = libxml2.parseDoc(xml)
+xml = response.read()
+doc = etree.XML(xml)
 
 dns = {}
 #parse out the VO names
-for vo in doc.xpathEval("//VO"):
+for vo in doc.xpath("//VO"):
 
         #create good unixname
-        voname = vo.xpathEval("Name")[0].content
+        voname = vo.xpath("Name")[0].text
         voname = re.sub(r'[^/a-z0-9]+', '', voname.lower())
 
         username = "ouser."+voname
         groupname = "cvmfs"
 
-        for dn in vo.xpathEval("OASIS/Managers/Manager/DNs/DN"):
-            dn = dn.content
+        for dn in vo.xpath("OASIS/Managers/Manager/DNs/DN"):
+            dn = dn.text
 
             ##sanitize dn
             original_dn = dn

--- a/share/generate_whitelists
+++ b/share/generate_whitelists
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import urllib.request
-import libxml2
+from lxml import etree
 import sys
 import os
 import time
@@ -23,8 +23,8 @@ logmsg('Starting')
 
 #download oasis vosummary
 response = urllib.request.urlopen("https://topology.opensciencegrid.org/vosummary/xml?summary_attrs_showoasis=on&all_vos=on&active=on&active_value=1&sort_key=name", timeout=30)
-xml = response.read().decode(response.headers.get_content_charset(failobj='utf-8'))
-doc = libxml2.parseDoc(xml)
+xml = response.read()
+doc = etree.XML(xml)
 
 # NOTE: although this downloads whitelists for all registered repositories,
 #   they are only really used by opensciencegrid.org and osgstorage.org
@@ -33,8 +33,8 @@ doc = libxml2.parseDoc(xml)
 #   downloaded .cvmfswhitelist files.
 
 #parse out OASISRepoURLs
-for urlfield in doc.xpathEval("//VO/OASIS/OASISRepoURLs/URL"):
-    url = urlfield.content
+for urlfield in doc.xpath("//VO/OASIS/OASISRepoURLs/URL"):
+    url = urlfield.text
     if url[-1] == '/':
       # remove a trailing slash
       url = url[:-1]

--- a/share/print_oasis_vonames
+++ b/share/print_oasis_vonames
@@ -1,18 +1,18 @@
 #!/usr/bin/python3
 
 import urllib.request
-import libxml2
+from lxml import etree
 import sys
 import re
 
 response = urllib.request.urlopen("https://topology.opensciencegrid.org/vosummary/xml?summary_attrs_showoasis=on&all_vos=on&active=on&active_value=1&oasis=on&oasis_value=1&sort_key=name", timeout=30)
-xml = response.read().decode(response.headers.get_content_charset(failobj='utf-8'))
-doc = libxml2.parseDoc(xml)
+xml = response.read()
+doc = etree.XML(xml)
 
 vonames = []
-for vo in doc.xpathEval("//VO"):
-    voname = vo.xpathEval("Name")[0].content
-    if vo.xpathEval("OASIS/Managers/Manager"):
+for vo in doc.xpath("//VO"):
+    voname = vo.xpath("Name")[0].text
+    if vo.xpath("OASIS/Managers/Manager"):
         voname = re.sub(r'[^/a-z0-9]+', '', voname.lower())
         vonames.append(voname)
 


### PR DESCRIPTION
The conversion to python3 done last July in support of el8 did not work on el7 due to the lack of a python3-libxml2 package.  This converts the scripts to use lxml instead of libxml2, because it is available on both.