### PR TITLE
do_du: send duration of repo du to syslog

### DIFF
--- a/share/do_du
+++ b/share/do_du
@@ -15,7 +15,9 @@ echo $$ >$LOCKFILE
 cd /srv/cvmfs
 for d in *.*; do
     echo "Starting du of $d at `date`"
+    SECONDS=0 # reset counter
     du -ks $d
+    logger -t oasis-do_du "Finished du of $d in $SECONDS sec"
 done
 echo "Finished at `date`"
 echo


### PR DESCRIPTION
Log the duration of each repo du run for easier review